### PR TITLE
fix: harden runner cleanup maintenance paths

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -22,7 +22,7 @@ body:
     id: workflow
     attributes:
       label: Workflow Snippet
-      description: Include the step that runs this action
+      description: Include the step that runs this action and redact any secrets or private values
       render: yaml
     validations:
       required: true
@@ -60,6 +60,6 @@ body:
     id: logs
     attributes:
       label: Logs
-      description: Include the relevant run output
+      description: Include the relevant run output after redacting tokens, credentials, and private paths
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security Vulnerability Reporting
-    url: https://github.com/justinthelaw/maximize-github-runner-space/blob/master/docs/SECURITY.md
+    url: https://github.com/justinthelaw/maximize-github-runner-space/blob/main/docs/SECURITY.md
     about: Please follow SECURITY.md and do not disclose vulnerabilities publicly.
   - name: Support Guidance
-    url: https://github.com/justinthelaw/maximize-github-runner-space/blob/master/docs/SUPPORT.md
+    url: https://github.com/justinthelaw/maximize-github-runner-space/blob/main/docs/SUPPORT.md
     about: Read SUPPORT.md before opening an issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,7 +4,7 @@ Describe what changed and why.
 
 ## Validation
 
-- [ ] `pre-commit run --all-files`
+- [ ] `pre-commit run --all-files --hook-stage pre-push`
 - [ ] Test workflow assertions remain accurate
 - [ ] README and docs updated for behavior changes
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -15,6 +16,7 @@ concurrency:
 jobs:
   pre-commit:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -24,7 +26,8 @@ jobs:
         with:
           python-version: "3.14"
 
+      - name: Install Pre-Commit
+        run: python -m pip install pre-commit==4.6.0
+
       - name: Run Pre-Commits
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-        with:
-          extra_args: --all-files --hook-stage pre-commit
+        run: pre-commit run --all-files --hook-stage pre-push

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   pull_request:
     branches:
       - main
@@ -15,6 +16,7 @@ concurrency:
 jobs:
   static-validation:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -37,6 +39,14 @@ jobs:
                   stripped = line.strip()
                   if stripped.startswith("uses: actions/checkout@") and expected_checkout not in stripped:
                       raise SystemExit(f"Unpinned or stale checkout reference at {workflow}:{line_number}: {line.strip()}")
+                  if stripped.startswith("uses:"):
+                      action_ref = stripped.removeprefix("uses:").strip().split()[0]
+                      if not action_ref.startswith("./"):
+                          if "@" not in action_ref:
+                              raise SystemExit(f"Remote action has no revision at {workflow}:{line_number}: {line.strip()}")
+                          revision = action_ref.rsplit("@", 1)[-1]
+                          if len(revision) != 40 or any(character not in "0123456789abcdef" for character in revision):
+                              raise SystemExit(f"Remote action is not pinned to a full SHA at {workflow}:{line_number}: {line.strip()}")
 
           action_text = Path("action.yml").read_text(encoding="utf-8")
           disallowed_temp_paths = (
@@ -88,6 +98,7 @@ jobs:
 
   default-max:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -97,6 +108,7 @@ jobs:
 
   no-op-custom:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -153,6 +165,7 @@ jobs:
 
   max-with-skip:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -195,6 +208,7 @@ jobs:
 
   max-skip-cached-node-precedence:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -242,6 +256,7 @@ jobs:
 
   max-skip-firefox-precedence:
     runs-on: ubuntu-latest
+    timeout-minutes: 45
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -267,7 +282,7 @@ jobs:
         uses: ./
         with:
           cleanup-profile: max
-          skip-components: "  FireFox , LARGE-Packages "
+          skip-components: "  FireFox  "
 
       - name: Verify Firefox Is Kept But Chrome Can Be Removed
         shell: bash
@@ -286,6 +301,7 @@ jobs:
 
   custom-grouped-subgroup-precedence:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -331,18 +347,30 @@ jobs:
 
   invalid-input-validation:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     strategy:
       matrix:
         scenario:
           - name: invalid-cleanup-profile
             cleanup_profile: invalid-profile
             skip_components: ""
+            swapfile_size: ""
           - name: invalid-skip-components
             cleanup_profile: max
             skip_components: not-a-real-component
+            swapfile_size: ""
           - name: mixed-valid-invalid-skip-components
             cleanup_profile: max
             skip_components: dotnet,not-a-real-component
+            swapfile_size: ""
+          - name: undersized-swapfile
+            cleanup_profile: custom
+            skip_components: ""
+            swapfile_size: 1B
+          - name: overflowing-swapfile
+            cleanup_profile: custom
+            skip_components: ""
+            swapfile_size: 100000000000000000000TiB
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -354,6 +382,7 @@ jobs:
         with:
           cleanup-profile: ${{ matrix.scenario.cleanup_profile }}
           skip-components: ${{ matrix.scenario.skip_components }}
+          swapfile-size: ${{ matrix.scenario.swapfile_size }}
 
       - name: Verify Invalid Inputs Fail Early
         shell: bash
@@ -365,9 +394,39 @@ jobs:
             exit 1
           fi
 
+  conda-root-safety:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Create Traversal Fixture
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "TEST_SENTINEL=${RUNNER_TEMP}/conda-safety-sentinel" >> "$GITHUB_ENV"
+          mkdir -p "${RUNNER_TEMP}/conda-safety-sentinel"
+          touch "${RUNNER_TEMP}/conda-safety-sentinel/keep"
+          relative_sentinel=$(realpath --relative-to="$RUNNER_TOOL_CACHE" "${RUNNER_TEMP}/conda-safety-sentinel")
+          echo "TEST_CONDA=${RUNNER_TOOL_CACHE}/${relative_sentinel}" >> "$GITHUB_ENV"
+
+      - name: Reject Traversing CONDA Root
+        uses: ./
+        env:
+          CONDA: ${{ env.TEST_CONDA }}
+        with:
+          cleanup-profile: custom
+          remove-miniconda: "true"
+
+      - name: Verify Unrelated Directory Was Kept
+        shell: bash
+        run: test -f "${TEST_SENTINEL}/keep"
+
 
   swapfile-resize:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -401,6 +460,7 @@ jobs:
 
   swapfile-remove:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -423,6 +483,7 @@ jobs:
 
   swapfile-oversize:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -487,6 +548,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     strategy:
       matrix:
         option:

--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -18,7 +18,6 @@
   },
   "ignores": [
     "LICENSE",
-    ".github/",
     ".git/"
   ]
 }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -52,7 +52,7 @@ repos:
     hooks:
       - id: yamllint
         name: YAML Lint
-        args: ["-c=.yamllint"]
+        args: ["--strict", "-c=.yamllint"]
         stages: [pre-commit, pre-push]
 
   - repo: https://github.com/rhysd/actionlint

--- a/.yamllint
+++ b/.yamllint
@@ -13,11 +13,11 @@ rules:
   commas: enable
   comments:
     level: warning
+    min-spaces-from-content: 1
   comments-indentation:
     level: warning
   document-end: disable
-  document-start:
-    level: warning
+  document-start: disable
   empty-lines: enable
   empty-values: disable
   float-values: disable
@@ -32,4 +32,5 @@ rules:
   quoted-strings: disable
   trailing-spaces: enable
   truthy:
+    check-keys: false
     level: warning

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This action removes optional preinstalled SDKs, toolchains, and caches so your w
 
 ## Why use this action?
 
-GitHub-hosted Ubuntu runners often start with many gigabytes consumed by preinstalled software. That is convenient for general use, but it can block large workflows (for example, Docker image builds, Android/iOS builds, or large monorepo test runs).
+GitHub-hosted Ubuntu runners often start with many gigabytes consumed by preinstalled software. That is convenient for general use, but it can block large workflows (for example, Docker image builds, Android builds, or large monorepo test runs).
 
 This action helps by:
 
@@ -48,11 +48,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Free Runner Space
-        # NOTE: Use a specific tag or commit shasum for immutability
-        uses: justinthelaw/maximize-github-runner-space@latest
+        # Pin a full commit SHA instead when your policy requires immutability.
+        uses: justinthelaw/maximize-github-runner-space@v0.10.0
         with:
           skip-components: java,browsers,docker-engine
           swapfile-size: 2G
@@ -72,11 +72,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Free Runner Space
-        # NOTE: Use a specific tag or commit shasum for immutability
-        uses: justinthelaw/maximize-github-runner-space@latest
+        # Pin a full commit SHA instead when your policy requires immutability.
+        uses: justinthelaw/maximize-github-runner-space@v0.10.0
         with:
           cleanup-profile: custom
           remove-android: "true"
@@ -111,6 +111,8 @@ Use `swapfile-size` only when you want to change the runner's existing swapfile.
 - Decimal sizes such as `1.5GiB`.
 - Unit-suffixed values such as `512MiB`, `2G`, or `0.5TiB`.
 - A plain number like `2`, which is interpreted as GiB.
+
+Positive sizes must be at least 1 MiB and fit in signed 64-bit byte arithmetic.
 
 If the requested size would exceed the safe free space available on `/mnt`, the action exits with an error and leaves the existing swapfile unchanged. When the size is accepted, the configured swapfile remains available for the rest of the job.
 
@@ -192,7 +194,8 @@ For grouped areas like browsers and toolcache, listing a subcomponent in `skip-c
 The CI workflow includes targeted interaction tests beyond single-input toggles. These lock in:
 
 - `cleanup-profile: max` + `skip-components: cached-node` keeps Node toolcache while still allowing other toolcache families (for example Python) to be removed.
-- `cleanup-profile: max` + `skip-components: firefox,large-packages` keeps Firefox while still allowing other browser artifacts (for example Chrome) to be removed.
+- `cleanup-profile: max` + `skip-components: firefox` keeps Firefox while still allowing other browser artifacts (for example Chrome) to be removed.
+- The legacy `large-packages` bulk purge is suppressed when a skipped component overlaps its package list; dedicated non-skipped component cleanups still run.
 - `cleanup-profile: custom` + `remove-browsers: "true"` + `remove-firefox: "true"` uses grouped precedence (`remove-browsers`) so subgroup removals are not scheduled separately.
 - `skip-components` normalization behavior for whitespace and mixed case values.
 
@@ -299,7 +302,7 @@ The CI workflow includes targeted interaction tests beyond single-input toggles.
 | ----------------------- | ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
 | `remove-powershell`     | `powershell`     | `powershell` package, `pwsh` binary                                                                                                          |
 | `swapfile-size`         | N/A              | Reconfigures `/mnt/swapfile` only when set; `0` removes it, otherwise the requested size is applied or the action fails before changing swap |
-| `remove-large-packages` | `large-packages` | Legacy bulk apt purge (overlaps with several inputs)                                                                                         |
+| `remove-large-packages` | `large-packages` | Legacy bulk apt purge; suppressed in `max` when an overlapping component is skipped                                                          |
 
 ## Compatibility
 
@@ -309,7 +312,7 @@ The CI workflow includes targeted interaction tests beyond single-input toggles.
 
 ## Contributing
 
-See [CONTRIBUTING guide](/docs/CONTRIBUTING.md) for development and release workflow details.
+See [CONTRIBUTING guide](/docs/CONTRIBUTING.md) for development and contribution guidance.
 
 ## Migration Guide
 

--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
     required: false
     default: "false"
   swapfile-size:
-    description: "Optional swapfile size. Accepts 0, 1.5GiB, 512MiB, or a plain GiB value like 2. Leaves the runner swapfile untouched when omitted."
+    description: "Optional swapfile size. Accepts 0 or a positive size of at least 1 MiB, such as 1.5GiB, 512MiB, or a plain GiB value like 2. Leaves the runner swapfile untouched when omitted."
     required: false
     default: ""
 
@@ -318,7 +318,7 @@ runs:
         parse_swapfile_size_bytes() {
           local raw="${1:-}"
 
-          python3 -c $'import re\nimport sys\nfrom decimal import Decimal, InvalidOperation, ROUND_HALF_UP\n\nraw = sys.argv[1].strip()\nmatch = re.fullmatch(r"([0-9]+(?:\\.[0-9]+)?)([kmgt]i?b?)?", raw, re.IGNORECASE)\nif not match:\n    raise SystemExit(1)\n\ntry:\n    value = Decimal(match.group(1))\nexcept InvalidOperation:\n    raise SystemExit(1)\n\nif value < 0:\n    raise SystemExit(1)\n\nunit = (match.group(2) or "gib").lower()\nmultipliers = {\n    "k": 1024,\n    "kb": 1024,\n    "ki": 1024,\n    "kib": 1024,\n    "m": 1024 ** 2,\n    "mb": 1024 ** 2,\n    "mi": 1024 ** 2,\n    "mib": 1024 ** 2,\n    "g": 1024 ** 3,\n    "gb": 1024 ** 3,\n    "gi": 1024 ** 3,\n    "gib": 1024 ** 3,\n    "t": 1024 ** 4,\n    "tb": 1024 ** 4,\n    "ti": 1024 ** 4,\n    "tib": 1024 ** 4,\n}\n\nbytes_value = (value * multipliers[unit]).to_integral_value(rounding=ROUND_HALF_UP)\nprint(int(bytes_value))' "$raw"
+          python3 -c $'import re\nimport sys\nfrom decimal import Decimal, InvalidOperation, ROUND_HALF_UP\n\nraw = sys.argv[1].strip()\nmatch = re.fullmatch(r"([0-9]+(?:\\.[0-9]+)?)([kmgt]i?b?)?", raw, re.IGNORECASE)\nif not match:\n    raise SystemExit(1)\n\ntry:\n    value = Decimal(match.group(1))\nexcept InvalidOperation:\n    raise SystemExit(1)\n\nif value < 0:\n    raise SystemExit(1)\n\nunit = (match.group(2) or "gib").lower()\nmultipliers = {\n    "k": 1024,\n    "kb": 1024,\n    "ki": 1024,\n    "kib": 1024,\n    "m": 1024 ** 2,\n    "mb": 1024 ** 2,\n    "mi": 1024 ** 2,\n    "mib": 1024 ** 2,\n    "g": 1024 ** 3,\n    "gb": 1024 ** 3,\n    "gi": 1024 ** 3,\n    "gib": 1024 ** 3,\n    "t": 1024 ** 4,\n    "tb": 1024 ** 4,\n    "ti": 1024 ** 4,\n    "tib": 1024 ** 4,\n}\n\nbytes_value = int((value * multipliers[unit]).to_integral_value(rounding=ROUND_HALF_UP))\nif bytes_value != 0 and bytes_value < 1024 ** 2:\n    raise SystemExit(1)\nif bytes_value > 2 ** 63 - 1:\n    raise SystemExit(1)\nprint(bytes_value)' "$raw"
         }
 
         should_enable() {
@@ -475,6 +475,15 @@ runs:
         COMPONENT_NGINX=$(should_enable "nginx" "${REMOVE_NGINX}")
         COMPONENT_DOCKER_IMAGES=$(should_enable "docker-images" "${REMOVE_DOCKER_IMAGES}")
         COMPONENT_LARGE_PACKAGES=$(should_enable "large-packages" "${REMOVE_LARGE_PACKAGES}")
+        if [[ "${CLEANUP_PROFILE}" == "max" && "${COMPONENT_LARGE_PACKAGES}" == "true" ]]; then
+          for overlapping_component in \
+            dotnet php mysql azure-cli gcloud-cli browsers chrome chromium edge firefox powershell; do
+            if csv_contains "$SKIP_COMPONENTS_NORMALIZED" "$overlapping_component"; then
+              COMPONENT_LARGE_PACKAGES="false"
+              break
+            fi
+          done
+        fi
 
         if [[ "$COMPONENT_CACHED_TOOLS" == "true" ]]; then
           COMPONENT_CACHED_GO="false"
@@ -870,10 +879,16 @@ runs:
         if [[ "$COMPONENT_MINICONDA" == "true" ]]; then
           {
             echo "Removing Miniconda..."
-            conda_root="${CONDA:-/usr/share/miniconda}"
-            if [[ -n "$conda_root" && "$conda_root" != "/" ]]; then
-              safe_rm "$conda_root"
-            fi
+            conda_root=$(realpath -m -- "${CONDA:-/usr/share/miniconda}")
+            toolcache_root=$(realpath -m -- "${TOOLCACHE_DIR:-/opt/hostedtoolcache}")
+            case "$conda_root" in
+              /usr/share/miniconda|"${toolcache_root}"/*)
+                safe_rm "$conda_root"
+                ;;
+              *)
+                echo "Skipping unexpected CONDA root: ${conda_root}"
+                ;;
+            esac
             safe_rm /home/runner/.conda
             sudo rm -f /home/runner/.condarc 2>/dev/null || true
             safe_rm /home/runner/.cache/conda
@@ -1049,7 +1064,9 @@ runs:
           safe_rm /usr/lib/jvm
           safe_rm /usr/local/lib/jvm
           if [[ -n "${TOOLCACHE_DIR:-}" && "${TOOLCACHE_DIR}" != "/" ]]; then
-            safe_rm "${TOOLCACHE_DIR}"/Java*
+            for java_cache in "${TOOLCACHE_DIR}"/Java*; do
+              [[ -e "$java_cache" ]] && safe_rm "$java_cache"
+            done
           fi
           sudo update-alternatives --remove-all java 2>/dev/null || true
           sudo update-alternatives --remove-all javac 2>/dev/null || true
@@ -1368,28 +1385,23 @@ runs:
 
             disable_managed_swapfile() {
               if swapon --show=NAME --noheadings 2>/dev/null | awk '{print $1}' | grep -Fxq '/mnt/swapfile'; then
-                sudo swapoff /mnt/swapfile 2>/dev/null || true
+                sudo swapoff /mnt/swapfile
               fi
             }
 
             remove_managed_swapfile() {
               disable_managed_swapfile
-              sudo sed -i '\|^/mnt/swapfile[[:space:]]\+none[[:space:]]\+swap[[:space:]]|d' /etc/fstab 2>/dev/null || true
-              sudo rm -f /mnt/swapfile 2>/dev/null || true
+              sudo sed -i '\|^/mnt/swapfile[[:space:]]\+none[[:space:]]\+swap[[:space:]]|d' /etc/fstab
+              sudo rm -f /mnt/swapfile
             }
 
             select_swapfile_size() {
               local requested_bytes="$1"
-              local existing_bytes=0
               local available_bytes reserve_bytes max_target_bytes
-
-              if [[ -f /mnt/swapfile ]]; then
-                existing_bytes=$(stat -c %s /mnt/swapfile 2>/dev/null || echo 0)
-              fi
 
               available_bytes=$(df --output=avail -B1 /mnt | tail -n1 | tr -d '[:space:]')
               reserve_bytes=$((512 * 1024 * 1024))
-              max_target_bytes=$((available_bytes + existing_bytes - reserve_bytes))
+              max_target_bytes=$((available_bytes - reserve_bytes))
               if (( max_target_bytes < 0 )); then
                 max_target_bytes=0
               fi
@@ -1405,27 +1417,68 @@ runs:
 
             create_swapfile() {
               local target_bytes="$1"
-              local mib_count remainder_bytes
+              local mib_count remainder_bytes replacement_path backup_path
+              local old_swap_active=0
 
-              remove_managed_swapfile
+              replacement_path=$(sudo mktemp /mnt/swapfile.new.XXXXXX)
+              backup_path="/mnt/swapfile.previous.$$"
 
               echo "Creating swapfile at /mnt/swapfile with size $(humanize_bytes "$target_bytes")..."
-              if ! sudo fallocate -l "$target_bytes" /mnt/swapfile 2>/dev/null; then
+              if ! sudo fallocate -l "$target_bytes" "$replacement_path" 2>/dev/null; then
                 mib_count=$((target_bytes / 1024 / 1024))
                 if (( mib_count > 0 )); then
-                  sudo dd if=/dev/zero of=/mnt/swapfile bs=1M count="$mib_count" status=none
+                  if ! sudo dd if=/dev/zero of="$replacement_path" bs=1M count="$mib_count" status=none; then
+                    sudo rm -f "$replacement_path"
+                    return 1
+                  fi
                 else
-                  sudo dd if=/dev/zero of=/mnt/swapfile bs=1 count=0 status=none
+                  sudo dd if=/dev/zero of="$replacement_path" bs=1 count=0 status=none
                 fi
                 remainder_bytes=$((target_bytes - mib_count * 1024 * 1024))
                 if (( remainder_bytes > 0 )); then
-                  sudo dd if=/dev/zero of=/mnt/swapfile bs=1 count="$remainder_bytes" seek=$((mib_count * 1024 * 1024)) conv=notrunc status=none
+                  if ! sudo dd if=/dev/zero of="$replacement_path" bs=1 count="$remainder_bytes" seek=$((mib_count * 1024 * 1024)) conv=notrunc status=none; then
+                    sudo rm -f "$replacement_path"
+                    return 1
+                  fi
                 fi
               fi
 
-              sudo chmod 600 /mnt/swapfile
-              sudo mkswap /mnt/swapfile >/dev/null
-              sudo swapon /mnt/swapfile
+              sudo chmod 600 "$replacement_path"
+              if ! sudo mkswap "$replacement_path" >/dev/null; then
+                sudo rm -f "$replacement_path"
+                return 1
+              fi
+
+              if swapon --show=NAME --noheadings 2>/dev/null | awk '{print $1}' | grep -Fxq '/mnt/swapfile'; then
+                old_swap_active=1
+              fi
+              if ! disable_managed_swapfile; then
+                sudo rm -f "$replacement_path"
+                return 1
+              fi
+
+              if [[ -e /mnt/swapfile ]] && ! sudo mv /mnt/swapfile "$backup_path"; then
+                [[ "$old_swap_active" == "1" ]] && sudo swapon /mnt/swapfile
+                sudo rm -f "$replacement_path"
+                return 1
+              fi
+
+              if ! sudo mv "$replacement_path" /mnt/swapfile; then
+                [[ -e "$backup_path" ]] && sudo mv "$backup_path" /mnt/swapfile
+                [[ "$old_swap_active" == "1" ]] && sudo swapon /mnt/swapfile
+                return 1
+              fi
+
+              if ! sudo swapon /mnt/swapfile; then
+                sudo rm -f /mnt/swapfile
+                if [[ -e "$backup_path" ]]; then
+                  sudo mv "$backup_path" /mnt/swapfile
+                  [[ "$old_swap_active" == "1" ]] && sudo swapon /mnt/swapfile
+                fi
+                return 1
+              fi
+
+              sudo rm -f "$backup_path"
               if ! grep -Eq '^/mnt/swapfile[[:space:]]+none[[:space:]]+swap[[:space:]]' /etc/fstab; then
                 echo '/mnt/swapfile none swap sw 0 0' | sudo tee -a /etc/fstab >/dev/null
               fi

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -15,9 +15,6 @@ This document is for action maintainers and contributors. If you only need to us
 - `action.yml`: Composite action inputs and cleanup implementation.
 - `.github/workflows/test.yml`: Matrix tests for input behavior, max-profile skip behavior, and grouped/subgroup precedence interactions.
 - `.github/workflows/lint.yml`: Pre-commit checks in CI.
-- `.github/workflows/release.yml`: Automated release PR and tagging flow.
-- `release-please-config.json`: Release Please configuration.
-- `.release-please-manifest.json`: Version manifest for Release Please.
 - `README.md`: End-user usage and input documentation.
 - `docs/MIGRATIONS.md`: Migration notes for breaking changes between releases.
 
@@ -52,7 +49,7 @@ Important safety notes:
 Run before pushing:
 
 ```bash
-pre-commit run --all-files
+pre-commit run --all-files --hook-stage pre-push
 ```
 
 At minimum, ensure:
@@ -61,20 +58,9 @@ At minimum, ensure:
 - Workflow lint (`actionlint`) passes.
 - Docs match current action inputs and behavior.
 
-## Release process (Release Please)
+## Commit guidance
 
-This repository uses [release-please](https://github.com/googleapis/release-please-action) to automate release PRs and tagging.
-
-### How it works
-
-- Commits merge into `main`.
-- The `release-please` workflow opens or updates a release PR.
-- The release PR updates `CHANGELOG.md` and version metadata.
-- Merging the release PR creates a GitHub release and tag.
-
-### Conventional commit guidance
-
-Use conventional-style commits when possible to generate clearer changelogs:
+Use conventional-style commits when possible to keep project history and release notes clear:
 
 - `feat:` for user-facing enhancements.
 - `fix:` for bug fixes.
@@ -87,5 +73,5 @@ Include in each PR:
 
 - What changed and why.
 - Any risk from removed packages/paths/toolchains.
-- Validation results (`pre-commit run --all-files`).
+- Validation results (`pre-commit run --all-files --hook-stage pre-push`).
 - Documentation updates when behavior changed.

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -5,6 +5,20 @@ This document captures breaking changes and notable behavior shifts between rele
 ## Table of Contents
 
 - [0.6.x -> 0.7.0](#06x---070)
+- [0.7.x -> 0.8.0](#07x---080)
+- [0.8.x -> 0.9.0](#08x---090)
+
+## 0.8.x -> 0.9.0
+
+Invalid `cleanup-profile` values and unknown `skip-components` entries now fail before cleanup begins. Correct misspelled or obsolete values instead of relying on them being ignored.
+
+## 0.7.x -> 0.8.0
+
+Swapfile management is now explicitly opt-in through `swapfile-size`:
+
+- Replace `remove-swapfile: "true"` with `swapfile-size: 0`.
+- Remove `swapfile` from `skip-components`; omitting `swapfile-size` now leaves the runner swapfile unchanged.
+- To resize swap instead of removing it, set a positive size such as `2G`.
 
 ## 0.6.x -> 0.7.0
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -2,12 +2,13 @@
 
 ## Supported Versions
 
-Only the latest state of `main` is supported.
+The latest state of `main` and the latest published minor release receive security fixes.
 
-| Version       | Supported |
-| ------------- | --------- |
-| `main`        | Yes       |
-| Older commits | No        |
+| Version                | Supported |
+| ---------------------- | --------- |
+| `main`                 | Yes       |
+| Latest published minor | Yes       |
+| Older minor releases   | No        |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
## Summary

- preserve `skip-components` across the overlapping legacy large-package purge
- make swapfile replacement rollback-safe and reject unsafe sizes before mutation
- constrain Miniconda cleanup roots and remove all matching Java toolcache entries
- harden CI pinning, stage coverage, timeouts, lint policy, and regression tests
- refresh usage, migration, contribution, issue, and security documentation

## Validation

- `pre-commit run --all-files --hook-stage pre-push`
- private-key and large-file checks
- Markdownlint, strict yamllint, and actionlint
- `bash -n` across all seven `action.yml` run blocks
- focused swap parser boundary checks
- independent security, CI/dependency, and documentation reviews

## Risk

Cleanup and swap behavior is intentionally destructive on GitHub-hosted Ubuntu runners. The changes tighten scope and add rollback behavior; the GitHub Actions integration matrix remains the authoritative live-runner validation.