### PR TITLE
chore: consolidate dependency updates for v0.12.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
           persist-credentials: false
 
       - name: Use the minimum supported Node.js version
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: "22"
           package-manager-cache: false

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ capabilities; callers do not select a platform manually.
 > [!IMPORTANT]
 > The cross-platform examples describe the planned `v0.12.1` release. Until it
 > is published, test this change by pinning the pull request's full commit SHA.
-> The current `v0.12.0` release is the stable cross-platform baseline.
+> The cross-platform capability baseline was introduced in `v0.12.0`.
 
 ## Table of contents
 

--- a/README.md
+++ b/README.md
@@ -13,9 +13,9 @@ capabilities; callers do not select a platform manually.
 > workflow needs.
 
 > [!IMPORTANT]
-> The cross-platform examples describe the planned `v0.12.0` release. Until it
+> The cross-platform examples describe the planned `v0.12.1` release. Until it
 > is published, test this change by pinning the pull request's full commit SHA.
-> The current `v0.11.0` release remains Ubuntu-only.
+> The current `v0.12.0` release is the stable cross-platform baseline.
 
 ## Table of contents
 
@@ -49,7 +49,7 @@ This action provides:
 
 ## Quick start
 
-All examples below use the planned `v0.12.0` tag for readability. Pin a full
+All examples below use the planned `v0.12.1` tag for readability. Pin a full
 commit SHA for immutable or security-sensitive workflows.
 
 ### Existing Ubuntu usage remains valid
@@ -66,7 +66,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Free runner space
-        uses: justinthelaw/maximize-github-runner-space@v0.12.0
+        uses: justinthelaw/maximize-github-runner-space@v0.12.1
       - run: ./build.sh
 ```
 
@@ -83,7 +83,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Free runner space
-        uses: justinthelaw/maximize-github-runner-space@v0.12.0
+        uses: justinthelaw/maximize-github-runner-space@v0.12.1
         with:
           skip-components: java,browsers,docker-engine,docker-images
           swapfile-size: 2GiB
@@ -111,7 +111,7 @@ jobs:
           persist-credentials: false
       - name: Free runner space
         id: cleanup
-        uses: justinthelaw/maximize-github-runner-space@v0.12.0
+        uses: justinthelaw/maximize-github-runner-space@v0.12.1
         with:
           cleanup-profile: custom
           remove-codeql: "true"
@@ -216,7 +216,7 @@ identical GitHub image remains indistinguishable and unsupported.
 ## Inputs
 
 The three global inputs and all historical `remove-*` inputs retain their names
-and defaults. The three OS-specific inputs at the end are additive in `v0.12.0`.
+and defaults. The three OS-specific inputs at the end are included in `v0.12.1`.
 
 ### Profiles and global options
 
@@ -294,9 +294,9 @@ and defaults. The three OS-specific inputs at the end are additive in `v0.12.0`.
 | `remove-apache` | `apache` | Linux, Windows | Stop and remove runner Apache artifacts when installed. |
 | `remove-nginx` | `nginx` | Linux, macOS, Windows | Stop and remove runner Nginx artifacts when installed. |
 | `remove-large-packages` | `large-packages` | Linux | Run the backward-compatible legacy bulk apt cleanup. |
-| `remove-xcode` | `xcode` | macOS | Remove non-selected runner Xcode installations while preserving the active Xcode. New in `v0.12.0`. |
-| `remove-visual-studio` | `visual-studio` | Windows | Remove adapter-defined, guarded Visual Studio installations. New in `v0.12.0`. |
-| `remove-windows-sdk` | `windows-sdk` | Windows | Remove adapter-defined, guarded Windows SDK installations. New in `v0.12.0`. |
+| `remove-xcode` | `xcode` | macOS | Remove non-selected runner Xcode installations while preserving the active Xcode. Included in `v0.12.1`. |
+| `remove-visual-studio` | `visual-studio` | Windows | Remove adapter-defined, guarded Visual Studio installations. Included in `v0.12.1`. |
+| `remove-windows-sdk` | `windows-sdk` | Windows | Remove adapter-defined, guarded Windows SDK installations. Included in `v0.12.1`. |
 
 Every `remove-*` input defaults to `"false"`. Under `max`, those defaults are
 intentionally overridden and all applicable components are selected unless
@@ -362,7 +362,7 @@ requirements are known.
 Use a release tag when you want normal semantic-version updates:
 
 ```yaml
-- uses: justinthelaw/maximize-github-runner-space@v0.12.0
+- uses: justinthelaw/maximize-github-runner-space@v0.12.1
 ```
 
 Use the release commit's complete SHA when you require immutable action code:

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -13,8 +13,8 @@ This document captures breaking changes and notable behavior shifts between rele
 ## 0.11.x -> 0.12.0
 
 > [!NOTE]
-> `v0.12.0` is the stable cross-platform baseline. Test the planned `v0.12.1`
-> release by pinning the pull request's full commit SHA until its tag is published.
+> `v0.12.0` introduced the cross-platform capability changes described in this
+> section. It is the stable baseline for migrations from `v0.11.x`.
 
 This release changes the implementation from an Ubuntu-only composite action to a bundled Node action with native Linux, macOS, and Windows adapters.
 

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -5,6 +5,7 @@ This document captures breaking changes and notable behavior shifts between rele
 ## Table of Contents
 
 - [0.11.x -> 0.12.0](#011x---0120)
+- [0.12.0 -> 0.12.1](#0120---0121)
 - [0.6.x -> 0.7.0](#06x---070)
 - [0.7.x -> 0.8.0](#07x---080)
 - [0.8.x -> 0.9.0](#08x---090)
@@ -12,7 +13,8 @@ This document captures breaking changes and notable behavior shifts between rele
 ## 0.11.x -> 0.12.0
 
 > [!NOTE]
-> `v0.12.0` is planned but not yet published. Until release, test the pull request by pinning its full commit SHA.
+> `v0.12.0` is the stable cross-platform baseline. Test the planned `v0.12.1`
+> release by pinning the pull request's full commit SHA until its tag is published.
 
 This release changes the implementation from an Ubuntu-only composite action to a bundled Node action with native Linux, macOS, and Windows adapters.
 
@@ -31,6 +33,15 @@ For a new macOS or Windows workflow, start with `cleanup-profile: custom` and en
 Linux `remove-homebrew` is intentionally more conservative than v0.11. The runner-image definition installs no formulae or casks, so the action now verifies the fixed Linuxbrew executable and runs native stale-artifact cleanup while preserving the prefix and workflow-installed packages. Workflows that depended on deleting the entire Linuxbrew installation should expect less reclaimed space rather than unsafe ownership of files added before the action runs.
 
 The action now rejects self-hosted runners, arbitrary job containers, and hosted image identities outside the supported Ubuntu, macOS, and Windows runner-image definitions before cleanup. VM authorization reads the fixed runner-images image-data record instead of trusting workflow-overridable `ImageOS` or `ImageVersion` values. This compatibility gate is not signed attestation and does not prove a runner's billing or size class, so larger runners remain unsupported and outside the tested contract rather than being guaranteed rejection cases. These checks apply to both `max` and `custom`; selecting `custom` does not extend the support boundary. See [Runner support](/docs/RUNNER-SUPPORT.md) for exact labels and limitations.
+
+## 0.12.0 -> 0.12.1
+
+This maintenance release consolidates the current dependency updates and refreshes
+the workflow's pinned Node setup action. Runtime cleanup behavior, public inputs,
+outputs, and the supported runner contract remain unchanged.
+
+No workflow migration is required. Continue pinning the full commit SHA while the
+`v0.12.1` tag is being prepared.
 
 ## 0.8.x -> 0.9.0
 

--- a/docs/RUNNER-SUPPORT.md
+++ b/docs/RUNNER-SUPPORT.md
@@ -1,6 +1,6 @@
 # Runner support and implementation notes
 
-This document describes the runner contract for the planned `v0.12.0` release
+This document describes the runner contract for the planned `v0.12.1` release
 of Maximize GitHub Runner Space. The runner and image inventory was verified on
 2026-08-12 against GitHub's current documentation and
 [`actions/runner-images@20f9f7b`](https://github.com/actions/runner-images/tree/20f9f7b2d2dbcf53e5c5a7e133f4867e8a555c24).
@@ -462,7 +462,7 @@ Two independent versions affect a workflow:
 2. The runner label determines the operating system and installed inventory.
 
 Pin the action to a full commit SHA for immutable execution. A semantic release
-tag such as `v0.12.0` is easier to read but can only be used after that release
+tag such as `v0.12.1` is easier to read but can only be used after that release
 exists. Pull request testers must use the PR commit SHA, not a not-yet-published
 tag.
 

--- a/docs/superpowers/plans/2026-08-13-dependency-consolidation-v0.12.1.md
+++ b/docs/superpowers/plans/2026-08-13-dependency-consolidation-v0.12.1.md
@@ -1,0 +1,249 @@
+# Dependency Consolidation v0.12.1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Publish one reviewable branch that contains every currently open dependency PR, verified dependency state, and documentation prepared for the v0.12.1 release.
+
+**Architecture:** Start from `main`, preserve both open Dependabot heads in one consolidation branch, then make only repository-wide dependency and release-documentation edits. The committed `dist/` bundle remains synchronized with `src/`; no runtime behavior changes are introduced.
+
+**Tech Stack:** Git, GitHub connector, Node.js 24/npm 11, TypeScript, Node test runner, Prettier, ncc, pre-commit, GitHub Actions.
+
+## Global Constraints
+
+- Include all open PRs found in `justinthelaw/maximize-github-runner-space` at the start of the task.
+- Update all declared dependency ecosystems that are stale; retain exact lockfile reproducibility.
+- Keep the TypeScript 7 build compatible with ncc by compiling TypeScript to JavaScript before bundling.
+- Change planned-release documentation references from `v0.12.0`/`0.12.0` to `v0.12.1`/`0.12.1` while preserving historical `v0.11.0` migration context.
+- Keep destructive action behavior unchanged.
+- Run the repository validation commands from `AGENTS.md` before publishing.
+- Do not close superseded PRs until the replacement branch is pushed and its PR is created.
+- Do not claim completion without fresh local and GitHub verification evidence.
+
+---
+
+### Task 1: Create the consolidation branch and merge open PRs
+
+**Files:**
+- Modify: none initially; merge commits will include the PR-owned files.
+
+**Interfaces:**
+- Consumes: `main`, `origin/dependabot/github_actions/github-actions-5c183d6ffa`, and `origin/dependabot/npm_and_yarn/javascript-action-f07d571036`.
+- Produces: `agent/consolidate-dependencies-v0.12.1` containing both PR diffs.
+
+- [ ] **Step 1: Create the branch from the current default branch**
+
+```bash
+git switch -c agent/consolidate-dependencies-v0.12.1 main
+```
+
+- [ ] **Step 2: Merge PR #45 without flattening its history**
+
+```bash
+git merge --no-ff origin/dependabot/github_actions/github-actions-5c183d6ffa \
+  -m "Merge PR #45: update actions/setup-node"
+```
+
+Expected changed file: `.github/workflows/test.yml`.
+
+- [ ] **Step 3: Merge PR #46 without flattening its history**
+
+```bash
+git merge --no-ff origin/dependabot/npm_and_yarn/javascript-action-f07d571036 \
+  -m "Merge PR #46: update TypeScript dependencies"
+```
+
+Expected changed files: `package.json` and `package-lock.json`.
+
+- [ ] **Step 4: Verify both PR diffs are present**
+
+```bash
+git diff --stat main...HEAD
+git diff -- .github/workflows/test.yml package.json | sed -n '1,220p'
+```
+
+Expected: setup-node is pinned to the PR #45 SHA/comment, TypeScript is 7.0.2, and Node types are 26.2.0.
+
+---
+
+### Task 2: Record the plan and update release-facing dependency documentation
+
+**Files:**
+- Create: `docs/superpowers/plans/2026-08-13-dependency-consolidation-v0.12.1.md`
+- Modify: `README.md`
+- Modify: `docs/RUNNER-SUPPORT.md`
+- Modify: `docs/MIGRATIONS.md`
+- Modify: `package.json`
+- Create: `tsconfig.build.json`
+- Modify: dependency manifests only if verification finds a stale declared version.
+
+**Interfaces:**
+- Consumes: merged dependency state from Task 1.
+- Produces: docs whose current planned-release references use v0.12.1 and a lockfile matching manifests.
+
+- [ ] **Step 1: Update planned-release references**
+
+Replace only the current planned-release references:
+
+```text
+v0.12.0 -> v0.12.1
+0.12.0  -> 0.12.1
+```
+
+Do not rewrite historical `v0.11.0` references or the historical `0.11.x -> 0.12.0` migration heading.
+
+- [ ] **Step 2: Check declared dependency versions against the merged lockfile**
+
+```bash
+node -e "const p=require('./package.json'); console.log(JSON.stringify({dependencies:p.dependencies,devDependencies:p.devDependencies},null,2))"
+node -e "const p=require('./package-lock.json'); console.log(JSON.stringify(p.packages[''],null,2))"
+```
+
+Expected: manifests and lockfile agree; no unrelated dependency is downgraded.
+
+- [ ] **Step 3: Keep the TypeScript 7 and ncc build boundary explicit**
+
+The ncc TypeScript loader is not compatible with the TypeScript 7 compiler API. Compile source files with `tsconfig.build.json` into `build/action`, then bundle `build/action/index.js` with ncc. Keep the test `tsconfig.json` unchanged so tests continue to compile into `build/test`.
+
+- [ ] **Step 4: Check the version-reference scope**
+
+```bash
+rg -n --hidden -g '!node_modules' -g '!.git' 'v0\\.12\\.0|0\\.12\\.0' README.md docs
+```
+
+Expected: no planned-release reference remains; any retained historical reference is explicitly justified in the diff.
+
+---
+
+### Task 3: Run local validation
+
+**Files:**
+- Modify: `dist/` only if `npm run check-dist` proves the committed bundle is stale.
+
+**Interfaces:**
+- Consumes: the complete consolidation branch.
+- Produces: fresh local evidence for typechecking, tests, formatting, bundle parity, and pre-commit checks.
+
+- [ ] **Step 1: Install locked dependencies without lifecycle scripts**
+
+```bash
+npm ci --ignore-scripts
+```
+
+- [ ] **Step 2: Run tests and formatting checks**
+
+```bash
+npm test
+npm run format:check
+```
+
+Expected: exit code 0 and no test failures or formatting changes.
+
+- [ ] **Step 3: Verify the committed action bundle**
+
+```bash
+npm run check-dist
+```
+
+Expected: generated `dist/` matches the committed bundle.
+
+- [ ] **Step 4: Run repository pre-commit validation**
+
+```bash
+pre-commit run --all-files --hook-stage pre-push
+```
+
+Expected: every configured hook passes.
+
+- [ ] **Step 5: Inspect the final local diff**
+
+```bash
+git diff --check
+git status --short
+git diff --stat main...HEAD
+```
+
+Expected: no whitespace errors and only consolidation, dependency, plan, and release-documentation changes.
+
+---
+
+### Task 4: Publish one review PR and retire superseded PRs
+
+**Files:**
+- Modify: remote branch `agent/consolidate-dependencies-v0.12.1`.
+- Create: one GitHub pull request targeting `main`.
+- Close: PRs #45 and #46 after the replacement PR exists.
+
+**Interfaces:**
+- Consumes: verified branch and validation evidence from Task 3.
+- Produces: one open, ready-for-review PR with a complete validation summary.
+
+- [ ] **Step 1: Commit the plan, docs, and any dependency corrections**
+
+```bash
+git add .
+git commit -m "chore: consolidate dependencies for v0.12.1"
+```
+
+- [ ] **Step 2: Push the branch**
+
+```bash
+git push -u origin agent/consolidate-dependencies-v0.12.1
+```
+
+- [ ] **Step 3: Create the replacement PR**
+
+Use the GitHub connector with base `main`, head `agent/consolidate-dependencies-v0.12.1`, and a body that lists the two superseded PRs plus every local validation command and result.
+
+- [ ] **Step 4: Close PRs #45 and #46**
+
+Close them through the GitHub connector only after the replacement PR URL and head SHA are confirmed.
+
+- [ ] **Step 5: Mark the replacement PR ready for review**
+
+If created as a draft, call the ready-for-review mutation and verify the PR is open, non-draft, and targets `main`.
+
+---
+
+### Task 5: Review, repair, and monitor the published PR
+
+**Files:**
+- Modify: only files required by verified CI failures or actionable review threads.
+
+**Interfaces:**
+- Consumes: replacement PR metadata, checks, reviews, and review threads.
+- Produces: an open PR with all required checks green and no unresolved actionable review comments.
+
+- [ ] **Step 1: Request a focused Codex code review of the final diff**
+
+Review the diff from `main` to the PR head for dependency integrity, release-documentation correctness, lockfile reproducibility, and accidental behavior changes.
+
+- [ ] **Step 2: Inspect GitHub checks and logs**
+
+Use the GitHub connector for PR metadata/status and `gh` if available; otherwise use the connector's workflow-run and job-log surfaces. Distinguish queued/in-progress, failed, skipped, and external checks.
+
+- [ ] **Step 3: Fix each actionable failure or comment with root-cause verification**
+
+For every change, reproduce locally where possible, make the smallest fix, rerun affected checks, commit, and push.
+
+- [ ] **Step 4: Repeat monitoring until stable**
+
+Poll the PR head checks and unresolved review threads after each push. Stop only when checks are green, the Codex review has no actionable comments, and the PR remains ready for review.
+
+---
+
+### Task 6: Final handoff
+
+**Files:**
+- Modify: none.
+
+**Interfaces:**
+- Consumes: final remote PR state.
+- Produces: a concise handoff with PR URL, branch, head SHA, validation evidence, and any residual external-check caveats.
+
+- [ ] **Step 1: Verify final repository state**
+
+Confirm the replacement PR is open, non-draft, based on `main`, all required checks are successful, PRs #45 and #46 are closed, and no unresolved actionable threads remain.
+
+- [ ] **Step 2: Notify the user to review the replacement PR**
+
+Include the exact PR link and a short summary of what was consolidated and validated.

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,10 +11,10 @@
         "@actions/core": "3.0.1"
       },
       "devDependencies": {
-        "@types/node": "24.3.0",
+        "@types/node": "26.2.0",
         "@vercel/ncc": "0.45.0",
         "prettier": "3.9.6",
-        "typescript": "5.9.3"
+        "typescript": "7.0.2"
       },
       "engines": {
         "node": ">=22"
@@ -56,13 +56,353 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "24.3.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.3.0.tgz",
-      "integrity": "sha512-aPTXCrfwnDLj4VvXrm+UUCQjNEvJgNA8s5F1cvwQU+3KNltTOkBm1j30uNLyqqPNe7gE3KFzImYoZEfLhp4Yow==",
+      "version": "26.2.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.2.0.tgz",
+      "integrity": "sha512-5IviulTZeRNp2vAJ514cc/HUlY5nZ9fCbq9DMyC52BrhFZACo3nI0R7qBxhQmo/d27NFe96ur/b7Wwxklda+kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.10.0"
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
       }
     },
     "node_modules/@vercel/ncc": {
@@ -101,17 +441,38 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
+        "tsc": "bin/tsc"
       },
       "engines": {
-        "node": ">=14.17"
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
       }
     },
     "node_modules/undici": {
@@ -124,9 +485,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.10.0.tgz",
-      "integrity": "sha512-t5Fy/nfn+14LuOc2KNYg75vZqClpAiqscVvMygNnlsHBFpSXdJaYtXMcdNLpl/Qvc3P2cB3s6lOV51nqsFq4ag==",
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/package.json
+++ b/package.json
@@ -8,12 +8,13 @@
     "node": ">=22"
   },
   "scripts": {
-    "build": "npm run clean:dist && ncc build src/index.ts --out dist --minify --no-source-map-register --license licenses.txt",
+    "build": "npm run clean:dist && npm run build:typescript && ncc build build/action/index.js --out dist --minify --no-source-map-register --license licenses.txt",
+    "build:typescript": "npm run clean && tsc --project tsconfig.build.json",
     "postbuild": "node -e \"import('node:fs').then(({ appendFileSync, readFileSync }) => { const path = 'dist/index.js'; if (!readFileSync(path, 'utf8').endsWith('\\n')) appendFileSync(path, '\\n'); })\"",
     "clean": "node -e \"import('node:fs').then(({rmSync}) => { rmSync('build', { recursive: true, force: true }); })\"",
     "clean:dist": "node -e \"import('node:fs').then(({rmSync}) => { rmSync('dist', { recursive: true, force: true }); })\"",
-    "format": "prettier --write action.yml scripts src test package.json tsconfig.json",
-    "format:check": "prettier --check action.yml scripts src test package.json tsconfig.json",
+    "format": "prettier --write action.yml scripts src test package.json tsconfig.build.json tsconfig.json",
+    "format:check": "prettier --check action.yml scripts src test package.json tsconfig.build.json tsconfig.json",
     "test": "npm run clean && tsc --project tsconfig.json && node --test \"build/test/*.test.js\"",
     "typecheck": "tsc --project tsconfig.json --noEmit",
     "check-dist": "npm run build && node scripts/check-dist.mjs"
@@ -22,9 +23,9 @@
     "@actions/core": "3.0.1"
   },
   "devDependencies": {
-    "@types/node": "24.3.0",
+    "@types/node": "26.2.0",
     "@vercel/ncc": "0.45.0",
     "prettier": "3.9.6",
-    "typescript": "5.9.3"
+    "typescript": "7.0.2"
   }
 }

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "newLine": "lf",
+    "noEmitOnError": true,
+    "outDir": "build/action",
+    "rootDir": "src",
+    "sourceMap": false
+  },
+  "include": ["src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary

- Consolidate the changes from #45 and #46 into one branch.
- Update `actions/setup-node` to v7.0.0.
- Update TypeScript to 7.0.2 and `@types/node` to 26.2.0.
- Compile TypeScript before ncc bundling so the TypeScript 7 compiler API remains compatible with the committed action bundle.
- Prepare README and migration/support documentation for the planned v0.12.1 release.
- Preserve runtime cleanup behavior and public action inputs/outputs.

## Supersedes

- #45 — `actions/setup-node` update
- #46 — TypeScript and Node typings update

## Validation

Local direct-command validation passed:

- TypeScript build with `tsconfig.build.json`
- ncc bundle generation with `@vercel/ncc@0.45.0`
- `node --test "build/test/*.test.js"` — 119 passed, 0 failed
- Prettier check
- Committed `dist/` parity check
- `git diff --check`
- `package.json` / `package-lock.json` dependency declaration check

The local `pre-commit` executable is not installed in the sandbox; the CI lint workflow is the authoritative pre-commit validation.